### PR TITLE
Improve login UI styling and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,32 @@
-# React + Vite
+# Admin Dashboard
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+A minimal admin dashboard built with [React](https://react.dev/) and [Vite](https://vitejs.dev/). It includes a login view and basic dashboard layout using Material UI.
 
-Currently, two official plugins are available:
+## Getting Started
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+Install dependencies and start the development server:
 
-## Expanding the ESLint configuration
+```bash
+npm install
+npm run dev
+```
 
-If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+The app will run at http://localhost:5173.
+
+## Scripts
+
+- `npm run dev` – Start the Vite dev server with hot module replacement.
+- `npm run build` – Build the app for production.
+- `npm run preview` – Preview the production build locally.
+- `npm run lint` – Lint the project with ESLint.
+
+## Project Structure
+
+- `src/` – Application source code.
+- `public/` – Static assets.
+- `index.html` – HTML entry point.
+
+## Contributing
+
+Pull requests are welcome. Please run `npm run lint` before submitting.
+

--- a/src/components/Dashboard/Dashboard.jsx
+++ b/src/components/Dashboard/Dashboard.jsx
@@ -118,11 +118,16 @@ const Dashboard = () => {
     setLogoutDialogOpen(true);
   };
 
-  const handleLogoutConfirm = () => {
+  const handleLogout = () => {
     localStorage.removeItem('adminToken');
     localStorage.removeItem('tokenType');
     localStorage.removeItem('isAuthenticated');
     navigate('/');
+  };
+
+  const handleLogoutConfirm = () => {
+    setLogoutDialogOpen(false);
+    handleLogout();
   };
 
   const handleLogoutCancel = () => {

--- a/src/components/Login/Login.jsx
+++ b/src/components/Login/Login.jsx
@@ -73,25 +73,28 @@ const Login = () => {
   };
 
   return (
-    <Container component="main" maxWidth="xs">
-      <Box
-        sx={{
-          marginTop: 8,
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'center',
-        }}
-      >
+    <Box
+      sx={{
+        minHeight: '100vh',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        background: 'linear-gradient(135deg, #e3f2fd 0%, #bbdefb 100%)',
+        p: 2,
+      }}
+    >
+      <Container component="main" maxWidth="xs">
         <Paper
-          elevation={3}
+          elevation={6}
           sx={{
-            padding: 4,
+            p: 4,
             display: 'flex',
             flexDirection: 'column',
             alignItems: 'center',
             backgroundColor: 'white',
             borderRadius: 2,
             width: '100%',
+            boxShadow: '0 4px 12px rgba(0,0,0,0.1)',
           }}
         >
           <Typography component="h1" variant="h5" sx={{ color: '#1976d2', mb: 3 }}>
@@ -135,15 +138,21 @@ const Login = () => {
               type="submit"
               fullWidth
               variant="contained"
-              sx={{ mt: 3, mb: 2, bgcolor: '#1976d2' }}
+              sx={{
+                mt: 3,
+                mb: 2,
+                bgcolor: '#1976d2',
+                textTransform: 'none',
+                '&:hover': { bgcolor: '#1565c0' },
+              }}
               disabled={loading}
             >
               {loading ? <CircularProgress size={24} color="inherit" /> : 'Sign In'}
             </Button>
           </Box>
         </Paper>
-      </Box>
-    </Container>
+      </Container>
+    </Box>
   );
 };
 


### PR DESCRIPTION
## Summary
- Add full-screen gradient backdrop and elevated card to login view
- Tweak login button styling for better hover behavior
- Factor out reusable `handleLogout` in dashboard to fix lint error
- Expand README with setup and usage instructions

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a05e172c68832ca2d216eb2a2dec75