### PR TITLE
Fix effect dependencies and reset admin creation role

### DIFF
--- a/src/components/Admin/AdminManagement.jsx
+++ b/src/components/Admin/AdminManagement.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import {
   Box,
   Button,
@@ -49,7 +49,7 @@ const AdminManagement = () => {
     role: 'viewer' // Default role
   });
 
-  const fetchAdmins = async () => {
+  const fetchAdmins = useCallback(async () => {
     try {
       const token = localStorage.getItem('adminToken');
       const tokenType = localStorage.getItem('tokenType');
@@ -133,7 +133,7 @@ const AdminManagement = () => {
       setError(errorMessage);
       setLoading(false);
     }
-  };
+  }, [page, rowsPerPage]);
 
   useEffect(() => {
     // Get user role from token when component mounts
@@ -147,7 +147,7 @@ const AdminManagement = () => {
       console.error('Error getting user role:', error);
     }
     fetchAdmins();
-  }, [page, rowsPerPage]);
+  }, [fetchAdmins]);
 
   const handleCreateAdmin = async () => {
     try {
@@ -171,7 +171,7 @@ const AdminManagement = () => {
 
       setSuccessMessage('Admin created successfully');
       setCreateDialogOpen(false);
-      setNewAdmin({ username: '', password: '', role: 'admin' });
+      setNewAdmin({ username: '', password: '', role: 'viewer' });
       fetchAdmins();
     } catch (err) {
       setError(err.message);

--- a/src/components/Dashboard/Dashboard.jsx
+++ b/src/components/Dashboard/Dashboard.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import {
   Box,
   Container,
@@ -43,7 +43,7 @@ const Dashboard = () => {
   const [dashboardStats, setDashboardStats] = useState(null);
   const [loading, setLoading] = useState(true);
 
-  const fetchDashboardStats = async () => {
+  const fetchDashboardStats = useCallback(async () => {
     try {
       const token = localStorage.getItem('adminToken');
       const tokenType = localStorage.getItem('tokenType');
@@ -75,14 +75,14 @@ const Dashboard = () => {
     } finally {
       setLoading(false);
     }
-  };
+  }, []);
 
   useEffect(() => {
     const fetchAdminProfile = async () => {
       try {
         const token = localStorage.getItem('adminToken');
         const tokenType = localStorage.getItem('tokenType');
-        
+
         if (!token || !tokenType) {
           throw new Error('No authentication token found');
         }
@@ -112,18 +112,18 @@ const Dashboard = () => {
 
     fetchAdminProfile();
     fetchDashboardStats();
-  }, []);
+  }, [fetchDashboardStats, handleLogout]);
 
   const handleLogoutClick = () => {
     setLogoutDialogOpen(true);
   };
 
-  const handleLogout = () => {
+  const handleLogout = useCallback(() => {
     localStorage.removeItem('adminToken');
     localStorage.removeItem('tokenType');
     localStorage.removeItem('isAuthenticated');
     navigate('/');
-  };
+  }, [navigate]);
 
   const handleLogoutConfirm = () => {
     setLogoutDialogOpen(false);

--- a/src/components/Users/UserList.jsx
+++ b/src/components/Users/UserList.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import {
   Box,
   Table,
@@ -9,7 +9,6 @@ import {
   TableRow,
   Paper,
   IconButton,
-  Typography,
   TablePagination,
   Button,
   Dialog,
@@ -42,7 +41,7 @@ const UserList = () => {
     setSuccessMessage(null);
   };
 
-  const fetchUsers = async () => {
+  const fetchUsers = useCallback(async () => {
     try {
       const token = localStorage.getItem('adminToken');
       const tokenType = localStorage.getItem('tokenType');
@@ -75,11 +74,11 @@ const UserList = () => {
     } finally {
       setLoading(false);
     }
-  };
+  }, [page, rowsPerPage]);
 
   useEffect(() => {
     fetchUsers();
-  }, [page, rowsPerPage]);
+  }, [fetchUsers]);
 
   const handleChangePage = (event, newPage) => {
     clearMessages();


### PR DESCRIPTION
## Summary
- stabilize data fetching hooks with `useCallback` and updated effect dependencies
- restore admin creation form to default viewer role after adding an admin

## Testing
- `npm run lint`
- `npm run build`
