### PR TITLE
Fix dashboard logout handler initialization

### DIFF
--- a/src/components/Dashboard/Dashboard.jsx
+++ b/src/components/Dashboard/Dashboard.jsx
@@ -43,6 +43,13 @@ const Dashboard = () => {
   const [dashboardStats, setDashboardStats] = useState(null);
   const [loading, setLoading] = useState(true);
 
+  const handleLogout = useCallback(() => {
+    localStorage.removeItem('adminToken');
+    localStorage.removeItem('tokenType');
+    localStorage.removeItem('isAuthenticated');
+    navigate('/');
+  }, [navigate]);
+
   const fetchDashboardStats = useCallback(async () => {
     try {
       const token = localStorage.getItem('adminToken');
@@ -117,13 +124,6 @@ const Dashboard = () => {
   const handleLogoutClick = () => {
     setLogoutDialogOpen(true);
   };
-
-  const handleLogout = useCallback(() => {
-    localStorage.removeItem('adminToken');
-    localStorage.removeItem('tokenType');
-    localStorage.removeItem('isAuthenticated');
-    navigate('/');
-  }, [navigate]);
 
   const handleLogoutConfirm = () => {
     setLogoutDialogOpen(false);


### PR DESCRIPTION
## Summary
- define `handleLogout` before it is used in `Dashboard` to avoid ReferenceError

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a08f232ca4832cbb924a0b2c731cce