### PR TITLE
feat: add dark mode toggle to dashboard

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,19 +1,9 @@
-import React from 'react';
+import React, { useMemo, useState } from 'react';
 import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
 import { CssBaseline, ThemeProvider, createTheme } from '@mui/material';
 import Login from './components/Login/Login';
 import Dashboard from './components/Dashboard/Dashboard';
-
-const theme = createTheme({
-  palette: {
-    primary: {
-      main: '#1976d2',
-    },
-    background: {
-      default: '#f5f5f5',
-    },
-  },
-});
+import { ColorModeContext } from './ColorModeContext';
 
 const PrivateRoute = ({ children }) => {
   const isAuthenticated = localStorage.getItem('isAuthenticated') === 'true';
@@ -21,23 +11,56 @@ const PrivateRoute = ({ children }) => {
 };
 
 function App() {
+  const [mode, setMode] = useState(() => localStorage.getItem('themeMode') || 'light');
+
+  const colorMode = useMemo(
+    () => ({
+      toggleColorMode: () => {
+        setMode(prevMode => {
+          const newMode = prevMode === 'light' ? 'dark' : 'light';
+          localStorage.setItem('themeMode', newMode);
+          return newMode;
+        });
+      },
+    }),
+    [],
+  );
+
+  const theme = useMemo(
+    () =>
+      createTheme({
+        palette: {
+          mode,
+          primary: {
+            main: '#1976d2',
+          },
+          background: {
+            default: mode === 'light' ? '#f5f5f5' : '#121212',
+          },
+        },
+      }),
+    [mode],
+  );
+
   return (
-    <ThemeProvider theme={theme}>
-      <CssBaseline />
-      <Router>
-        <Routes>
-          <Route path="/" element={<Login />} />
-          <Route
-            path="/dashboard"
-            element={
-              <PrivateRoute>
-                <Dashboard />
-              </PrivateRoute>
-            }
-          />
-        </Routes>
-      </Router>
-    </ThemeProvider>
+    <ColorModeContext.Provider value={colorMode}>
+      <ThemeProvider theme={theme}>
+        <CssBaseline />
+        <Router>
+          <Routes>
+            <Route path="/" element={<Login />} />
+            <Route
+              path="/dashboard"
+              element={
+                <PrivateRoute>
+                  <Dashboard />
+                </PrivateRoute>
+              }
+            />
+          </Routes>
+        </Router>
+      </ThemeProvider>
+    </ColorModeContext.Provider>
   );
 }
 

--- a/src/ColorModeContext.js
+++ b/src/ColorModeContext.js
@@ -1,0 +1,3 @@
+import React from 'react';
+
+export const ColorModeContext = React.createContext({ toggleColorMode: () => {} });

--- a/src/components/Dashboard/Dashboard.jsx
+++ b/src/components/Dashboard/Dashboard.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useContext } from 'react';
 import {
   Box,
   Container,
@@ -20,6 +20,7 @@ import {
   Button,
   Alert,
   CircularProgress,
+  useTheme,
 } from '@mui/material';
 import {
   Person as PersonIcon,
@@ -27,10 +28,13 @@ import {
   WorkHistory as WorkHistoryIcon,
   ExitToApp as ExitToAppIcon,
   Group as GroupIcon,
+  Brightness4 as Brightness4Icon,
+  Brightness7 as Brightness7Icon,
 } from '@mui/icons-material';
 import { useNavigate } from 'react-router-dom';
 import UserList from '../Users/UserList';
 import AdminManagement from '../Admin/AdminManagement';
+import { ColorModeContext } from '../../ColorModeContext';
 
 const API_URL = 'https://api.smartcareerassistant.online';
 
@@ -42,6 +46,8 @@ const Dashboard = () => {
   const [logoutDialogOpen, setLogoutDialogOpen] = useState(false);
   const [dashboardStats, setDashboardStats] = useState(null);
   const [loading, setLoading] = useState(true);
+  const theme = useTheme();
+  const colorMode = useContext(ColorModeContext);
 
   const handleLogout = useCallback(() => {
     localStorage.removeItem('adminToken');
@@ -166,6 +172,14 @@ const Dashboard = () => {
               </Typography>
             )}
           </Typography>
+          <IconButton
+            color="inherit"
+            onClick={colorMode.toggleColorMode}
+            sx={{ mr: 1 }}
+            aria-label="toggle dark mode"
+          >
+            {theme.palette.mode === 'dark' ? <Brightness7Icon /> : <Brightness4Icon />}
+          </IconButton>
           <IconButton color="inherit" onClick={handleLogoutClick}>
             <ExitToAppIcon />
           </IconButton>


### PR DESCRIPTION
## Summary
- add global color mode context and dynamic theme
- add dark mode toggle in dashboard app bar for better UI

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a094e244f4832cae8169119b1173d8