### PR TITLE
Refactor API layer and add testing setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+VITE_API_URL=https://api.smartcareerassistant.online

--- a/README.md
+++ b/README.md
@@ -13,12 +13,18 @@ npm run dev
 
 The app will run at http://localhost:5173.
 
+### Configuration
+
+The app reads its API base URL from the `VITE_API_URL` environment variable. Create a `.env` file based on `.env.example` and set
+`VITE_API_URL` to point to your backend. If unset, it defaults to `https://api.smartcareerassistant.online`.
+
 ## Scripts
 
 - `npm run dev` – Start the Vite dev server with hot module replacement.
 - `npm run build` – Build the app for production.
 - `npm run preview` – Preview the production build locally.
 - `npm run lint` – Lint the project with ESLint.
+- `npm test` – Run the test suite with Vitest.
 
 ## Project Structure
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -24,6 +24,7 @@ export default [
       ...js.configs.recommended.rules,
       ...reactHooks.configs.recommended.rules,
       'no-unused-vars': ['error', { varsIgnorePattern: '^[A-Z_]' }],
+      'no-console': 'warn',
       'react-refresh/only-export-components': [
         'warn',
         { allowConstantExport: true },

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "react": "^18.2.0",
@@ -16,7 +17,8 @@
     "@emotion/react": "^11.11.3",
     "@emotion/styled": "^11.11.0",
     "@mui/icons-material": "^5.15.11",
-    "react-router-dom": "^6.22.2"
+    "react-router-dom": "^6.22.2",
+    "prop-types": "^15.8.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",
@@ -27,6 +29,9 @@
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.19",
     "globals": "^16.0.0",
-    "vite": "^6.3.5"
+    "vite": "^6.3.5",
+    "vitest": "^2.1.1",
+    "@testing-library/react": "^16.0.0",
+    "@testing-library/jest-dom": "^6.4.2"
   }
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,13 +1,19 @@
-import React, { useMemo, useState } from 'react';
+import React, { useMemo, useState, useContext } from 'react';
 import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
 import { CssBaseline, ThemeProvider, createTheme } from '@mui/material';
 import Login from './components/Login/Login';
 import Dashboard from './components/Dashboard/Dashboard';
 import { ColorModeContext } from './ColorModeContext';
+import { AuthProvider, AuthContext } from './context/AuthContext';
+import PropTypes from 'prop-types';
 
 const PrivateRoute = ({ children }) => {
-  const isAuthenticated = localStorage.getItem('isAuthenticated') === 'true';
+  const { isAuthenticated } = useContext(AuthContext);
   return isAuthenticated ? children : <Navigate to="/" />;
+};
+
+PrivateRoute.propTypes = {
+  children: PropTypes.node.isRequired,
 };
 
 function App() {
@@ -43,25 +49,28 @@ function App() {
   );
 
   return (
-    <ColorModeContext.Provider value={colorMode}>
-      <ThemeProvider theme={theme}>
-        <CssBaseline />
-        <Router>
-          <Routes>
-            <Route path="/" element={<Login />} />
-            <Route
-              path="/dashboard"
-              element={
-                <PrivateRoute>
-                  <Dashboard />
-                </PrivateRoute>
-              }
-            />
-          </Routes>
-        </Router>
-      </ThemeProvider>
-    </ColorModeContext.Provider>
+    <AuthProvider>
+      <ColorModeContext.Provider value={colorMode}>
+        <ThemeProvider theme={theme}>
+          <CssBaseline />
+          <Router>
+            <Routes>
+              <Route path="/" element={<Login />} />
+              <Route
+                path="/dashboard"
+                element={
+                  <PrivateRoute>
+                    <Dashboard />
+                  </PrivateRoute>
+                }
+              />
+            </Routes>
+          </Router>
+        </ThemeProvider>
+      </ColorModeContext.Provider>
+    </AuthProvider>
   );
 }
 
 export default App;
+export { PrivateRoute };

--- a/src/__tests__/Dashboard.test.jsx
+++ b/src/__tests__/Dashboard.test.jsx
@@ -1,0 +1,40 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { vi, test, expect } from 'vitest';
+import Dashboard from '../components/Dashboard/Dashboard';
+import { AuthContext } from '../context/AuthContext';
+import { ColorModeContext } from '../ColorModeContext';
+import { MemoryRouter } from 'react-router-dom';
+
+vi.mock('../utils/api', () => ({
+  apiFetch: vi.fn((endpoint) => {
+    if (endpoint === '/auth/admin/dashboard') {
+      return Promise.resolve({
+        total_users: 1,
+        active_users_24h: 1,
+        total_cvs_analyzed: 0,
+        successful_analyses: 0,
+        failed_analyses: 0,
+        average_processing_time: 0,
+        top_fields: [],
+        recent_errors: [],
+      });
+    }
+    if (endpoint === '/auth/admin/me') {
+      return Promise.resolve({ username: 'admin', role: 'super_admin' });
+    }
+    return Promise.resolve({});
+  }),
+}));
+
+test('renders dashboard heading', async () => {
+  render(
+    <AuthContext.Provider value={{ logout: vi.fn(), isAuthenticated: true }}>
+      <ColorModeContext.Provider value={{ toggleColorMode: vi.fn() }}>
+        <MemoryRouter>
+          <Dashboard />
+        </MemoryRouter>
+      </ColorModeContext.Provider>
+    </AuthContext.Provider>
+  );
+  await waitFor(() => expect(screen.getByText(/Admin Dashboard/i)).toBeInTheDocument());
+});

--- a/src/__tests__/Login.test.jsx
+++ b/src/__tests__/Login.test.jsx
@@ -1,0 +1,23 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { vi, test, expect } from 'vitest';
+import Login from '../components/Login/Login';
+import { AuthContext } from '../context/AuthContext';
+
+vi.mock('../utils/api', () => ({
+  apiFetch: vi.fn(() => Promise.resolve({ access_token: 'token' })),
+}));
+
+test('logs in and calls context login', async () => {
+  const login = vi.fn();
+  render(
+    <AuthContext.Provider value={{ login }}>
+      <Login />
+    </AuthContext.Provider>
+  );
+
+  fireEvent.change(screen.getByLabelText(/username/i), { target: { value: 'admin' } });
+  fireEvent.change(screen.getByLabelText(/password/i), { target: { value: 'pass' } });
+  fireEvent.click(screen.getByRole('button', { name: /sign in/i }));
+
+  await waitFor(() => expect(login).toHaveBeenCalledWith('token'));
+});

--- a/src/__tests__/PrivateRoute.test.jsx
+++ b/src/__tests__/PrivateRoute.test.jsx
@@ -1,0 +1,26 @@
+import { render, screen } from '@testing-library/react';
+import { test, expect } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import { AuthContext } from '../context/AuthContext';
+import { PrivateRoute } from '../App';
+
+const renderWithAuth = (isAuthenticated) =>
+  render(
+    <AuthContext.Provider value={{ isAuthenticated }}>
+      <MemoryRouter>
+        <PrivateRoute>
+          <div>Secret</div>
+        </PrivateRoute>
+      </MemoryRouter>
+    </AuthContext.Provider>
+  );
+
+test('hides children when not authenticated', () => {
+  renderWithAuth(false);
+  expect(screen.queryByText('Secret')).toBeNull();
+});
+
+test('shows children when authenticated', () => {
+  renderWithAuth(true);
+  expect(screen.getByText('Secret')).toBeInTheDocument();
+});

--- a/src/components/Login/Login.jsx
+++ b/src/components/Login/Login.jsx
@@ -11,7 +11,9 @@ import {
 } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
 
-const API_URL = 'https://api.smartcareerassistant.online';
+import { apiFetch } from '../../utils/api';
+import { useContext } from 'react';
+import { AuthContext } from '../../context/AuthContext';
 
 const Login = () => {
   const [username, setUsername] = useState('');
@@ -19,6 +21,8 @@ const Login = () => {
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
   const navigate = useNavigate();
+
+  const { login } = useContext(AuthContext);
 
   const handleLogin = async (e) => {
     e.preventDefault();
@@ -34,36 +38,14 @@ const Login = () => {
       formData.append('client_id', 'string');
       formData.append('client_secret', 'string');
 
-      const response = await fetch(`${API_URL}/auth/admin/login`, {
+      const data = await apiFetch('/auth/admin/login', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/x-www-form-urlencoded',
-          'accept': 'application/json'
         },
-        body: formData
+        body: formData,
       });
-
-      const data = await response.json();
-
-      if (!response.ok) {
-        throw new Error(data.detail || 'Login failed');
-      }
-
-      console.log('Login response:', data);
-      console.log('Token from response:', data.access_token);
-      console.log('Token type from response:', data.token_type);
-      
-      // Store tokens
-      localStorage.setItem('adminToken', data.access_token);
-      localStorage.setItem('tokenType', 'Bearer'); // Always use Bearer
-      localStorage.setItem('isAuthenticated', 'true');
-      
-      // Verify storage
-      console.log('Stored token:', localStorage.getItem('adminToken'));
-      console.log('Stored token type:', localStorage.getItem('tokenType'));
-      
-      // Log full auth header that will be used
-      console.log('Auth header will be:', `Bearer ${data.access_token}`);
+      login(data.access_token);
       navigate('/dashboard');
     } catch (err) {
       setError(err.message || 'Failed to login. Please try again.');

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,1 @@
+export const API_URL = import.meta.env.VITE_API_URL || 'https://api.smartcareerassistant.online';

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -1,0 +1,49 @@
+import React, { createContext, useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
+
+export const AuthContext = createContext();
+
+export const AuthProvider = ({ children }) => {
+  const [token, setToken] = useState(localStorage.getItem('adminToken'));
+  const [isAuthenticated, setIsAuthenticated] = useState(false);
+
+  useEffect(() => {
+    if (token) {
+      try {
+        const { exp } = JSON.parse(atob(token.split('.')[1]));
+        if (exp * 1000 > Date.now()) {
+          setIsAuthenticated(true);
+        } else {
+          logout();
+        }
+      } catch {
+        logout();
+      }
+    }
+  }, [token]);
+
+  const login = (newToken) => {
+    localStorage.setItem('adminToken', newToken);
+    localStorage.setItem('isAuthenticated', 'true');
+    setToken(newToken);
+    setIsAuthenticated(true);
+  };
+
+  const logout = () => {
+    localStorage.removeItem('adminToken');
+    localStorage.removeItem('tokenType');
+    localStorage.removeItem('isAuthenticated');
+    setToken(null);
+    setIsAuthenticated(false);
+  };
+
+  return (
+    <AuthContext.Provider value={{ token, isAuthenticated, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+AuthProvider.propTypes = {
+  children: PropTypes.node.isRequired,
+};

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -1,0 +1,37 @@
+import { API_URL } from '../config';
+
+export const apiFetch = async (endpoint, options = {}) => {
+  const token = localStorage.getItem('adminToken');
+  const headers = {
+    Accept: 'application/json',
+    ...(options.headers || {}),
+  };
+  if (!headers['Content-Type'] && !(options.body instanceof FormData)) {
+    headers['Content-Type'] = 'application/json';
+  }
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+
+  const response = await fetch(`${API_URL}${endpoint}`, {
+    ...options,
+    headers,
+  });
+
+  if (!response.ok) {
+    let errorDetail = '';
+    try {
+      const data = await response.json();
+      errorDetail = data.detail || JSON.stringify(data);
+    } catch {
+      // ignore
+    }
+    throw new Error(errorDetail || response.statusText);
+  }
+
+  if (response.status === 204) {
+    return null;
+  }
+
+  return response.json();
+};

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,4 +4,8 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    setupFiles: './src/setupTests.js',
+  },
 })


### PR DESCRIPTION
## Summary
- centralize API URL and introduce reusable `apiFetch` helper
- implement `AuthContext` with token validation and update components
- add ESLint rule, documentation, and basic Vitest setup

## Testing
- `npm run lint`
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a09901e988832c9e27949037e6771b