### PR TITLE
Add Vercel config for SPA routing

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "cleanUrls": true,
+  "rewrites": [
+    {
+      "source": "/((?!api/).*)",
+      "destination": "/index.html"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add `vercel.json` config for React/Vite SPA with clean URLs

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find package @eslint/js)*


------
https://chatgpt.com/codex/tasks/task_e_68a0fc0d1234832cacaf894066d0952e