### PR TITLE
Configure SPA routing and add login password toggle

### DIFF
--- a/src/__tests__/Login.test.jsx
+++ b/src/__tests__/Login.test.jsx
@@ -1,5 +1,6 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { vi, test, expect } from 'vitest';
+import '@testing-library/jest-dom';
 import Login from '../components/Login/Login';
 import { AuthContext } from '../context/AuthContext';
 
@@ -20,4 +21,21 @@ test('logs in and calls context login', async () => {
   fireEvent.click(screen.getByRole('button', { name: /sign in/i }));
 
   await waitFor(() => expect(login).toHaveBeenCalledWith('token'));
+});
+
+test('toggles password visibility', () => {
+  render(
+    <AuthContext.Provider value={{ login: vi.fn() }}>
+      <Login />
+    </AuthContext.Provider>
+  );
+
+  const passwordField = screen.getByLabelText(/password/i);
+  const toggle = screen.getByLabelText(/show password/i);
+
+  expect(passwordField).toHaveAttribute('type', 'password');
+  fireEvent.click(toggle);
+  expect(passwordField).toHaveAttribute('type', 'text');
+  fireEvent.click(toggle);
+  expect(passwordField).toHaveAttribute('type', 'password');
 });

--- a/src/components/Login/Login.jsx
+++ b/src/components/Login/Login.jsx
@@ -7,8 +7,11 @@ import {
   Typography,
   Paper,
   Alert,
-  CircularProgress
+  CircularProgress,
+  IconButton,
+  InputAdornment
 } from '@mui/material';
+import { Visibility, VisibilityOff } from '@mui/icons-material';
 import { useTheme } from '@mui/material/styles';
 import { useNavigate } from 'react-router-dom';
 
@@ -19,6 +22,7 @@ import { AuthContext } from '../../context/AuthContext';
 const Login = () => {
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
+  const [showPassword, setShowPassword] = useState(false);
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
   const navigate = useNavigate();
@@ -117,11 +121,25 @@ const Login = () => {
               fullWidth
               name="password"
               label="Password"
-              type="password"
+              type={showPassword ? 'text' : 'password'}
               id="password"
               autoComplete="current-password"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
+              InputProps={{
+                endAdornment: (
+                  <InputAdornment position="end">
+                    <IconButton
+                      aria-label={showPassword ? 'Hide password' : 'Show password'}
+                      onClick={() => setShowPassword((prev) => !prev)}
+                      edge="end"
+                      disabled={loading}
+                    >
+                      {showPassword ? <VisibilityOff /> : <Visibility />}
+                    </IconButton>
+                  </InputAdornment>
+                ),
+              }}
             />
             <Button
               type="submit"

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "cleanUrls": true,
+  "rewrites": [
+    { "source": "/api/:path*", "destination": "/api/:path*" },
+    { "source": "/:path*", "destination": "/index.html" }
+  ]
+}


### PR DESCRIPTION
## Summary
- add `vercel.json` config for React/Vite SPA with clean URLs
- fix rewrite rules to properly handle API routes and deep links
- add eye button to toggle password visibility on the login form

## Testing
- `npm install` *(fails: 403 Forbidden retrieving @testing-library/jest-dom)*
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68a0fc0d1234832cacaf894066d0952e